### PR TITLE
#13 Add tf as an alias for terraform

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -2,6 +2,7 @@ tasks:
   - name: terraform
     before: |
       cd $PROJECT_ROOT
+      ./bin/tf_alias
       ./bin/terraform-install
       ./bin/generate_tf_credentials
   - name: aws-cli

--- a/bin/tf_alias
+++ b/bin/tf_alias
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+# Check if the alias already exists in the .bash_profile
+grep -q 'alias tf="terraform"' ~/.bash_profile
+
+# $? is a special variable in bash that holds the exit status of the last command executed
+if [ $? -ne 0 ]; then
+    # If the alias does not exist, append it
+    echo 'alias tf="terraform"' >> ~/.bash_profile
+    echo "Alias added successfully."
+else
+    # Inform the user if the alias already exists
+    echo "Alias already exists in .bash_profile."
+fi
+
+# Optional: source the .bash_profile to make the alias available immediately
+source ~/.bash_profile


### PR DESCRIPTION
```
gitpod /workspace/terraform-beginner-bootcamp-2023 (13-add-alias-for-terraform-command) $ tf -verison
Usage: terraform [global options] <subcommand> [args]

The available commands for execution are listed below.
The primary workflow commands are given first, followed by
less common or more advanced commands.
```