### PR TITLE
#24 Content Versioning

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -7,4 +7,5 @@ module "terrahouse_aws" {
   bucket_name = var.bucket_name
   index_html_filepath = var.index_html_filepath
   error_html_filepath = var.error_html_filepath
+  content_version = var.content_version
 }

--- a/modules/terrahouse_aws/resource-cdn.tf
+++ b/modules/terrahouse_aws/resource-cdn.tf
@@ -13,6 +13,10 @@ locals {
   s3_origin_id = "MyS3Origin"
 }
 
+resource "terraform_data" "content_version" {
+  input = var.content_version
+}
+
 # https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudfront_distribution
 resource "aws_cloudfront_distribution" "s3_distribution" {
   origin {

--- a/modules/terrahouse_aws/resource-storage.tf
+++ b/modules/terrahouse_aws/resource-storage.tf
@@ -27,8 +27,13 @@ resource "aws_s3_object" "index_html" {
   key    = "index.html"
   source = var.index_html_filepath
   content_type = "text/html"
-
+  
   etag = filemd5(var.index_html_filepath)
+  lifecycle {
+    replace_triggered_by = [terraform_data.content_version.output]
+    ignore_changes = [etag]
+  
+}
 }
 
 # https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_object

--- a/modules/terrahouse_aws/variables.tf
+++ b/modules/terrahouse_aws/variables.tf
@@ -39,3 +39,13 @@ variable "error_html_filepath" {
     error_message = "The provided path for error.html does not exist."
   }
 }
+
+variable "content_version" {
+  description = "The content version. Should be a positive integer starting at 1."
+  type        = number
+
+  validation {
+    condition     = var.content_version > 0 && floor(var.content_version) == var.content_version
+    error_message = "The content_version must be a positive integer starting at 1."
+  }
+}

--- a/public/index.html
+++ b/public/index.html
@@ -7,7 +7,7 @@
 </head>
 <body>
     <header>
-        <h1>Welcome to My Terraform Website</h1>
+        <h1>Welcome to My Terraform Website v2</h1>
     </header>
     <nav>
         <ul>

--- a/terraform.tfvars.example
+++ b/terraform.tfvars.example
@@ -1,4 +1,4 @@
 user_uuid="db8fc491-7712-4149-b2c2-19a84f7c3cc6"
-bucket_name="ivcj9ect1ex2hk158j7uozqdfbdj9f2lxxx"
+bucket_name="lolivcj9ect1ex2hk158j7uozqdfbdj9f2lxxyz"
 index_html_filepath="/workspace/terraform-beginner-bootcamp-2023/public/index.html"
 error_html_filepath="/workspace/terraform-beginner-bootcamp-2023/public/error.html"

--- a/variables.tf
+++ b/variables.tf
@@ -1,41 +1,28 @@
 variable "user_uuid" {
   description = "The UUID of the user"
   type        = string
-  validation {
-    condition        = can(regex("^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-5][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}$", var.user_uuid))
-    error_message    = "The user_uuid value is not a valid UUID."
-  }
 }
 
 variable "bucket_name" {
   description = "The name of the S3 bucket"
   type        = string
 
-  validation {
-    condition     = (
-      length(var.bucket_name) >= 3 && length(var.bucket_name) <= 63 && 
-      can(regex("^[a-z0-9][a-z0-9-.]*[a-z0-9]$", var.bucket_name))
-    )
-    error_message = "The bucket name must be between 3 and 63 characters, start and end with a lowercase letter or number, and can contain only lowercase letters, numbers, hyphens, and dots."
-  }
 }
 
 variable "index_html_filepath" {
   description = "The file path for index.html"
   type        = string
 
-  validation {
-    condition     = fileexists(var.index_html_filepath)
-    error_message = "The provided path for index.html does not exist."
-  }
+  
 }
 
 variable "error_html_filepath" {
   description = "The file path for error.html"
   type        = string
 
-  validation {
-    condition     = fileexists(var.error_html_filepath)
-    error_message = "The provided path for error.html does not exist."
-  }
+  
+}
+
+variable "content_version" {
+  type        = number
 }


### PR DESCRIPTION
Only once content version input is updated , index.html is uploaded

```tf
 # module.terrahouse_aws.aws_s3_object.index_html will be replaced due to changes in replace_triggered_by
-/+ resource "aws_s3_object" "index_html" {
      + acl                    = (known after apply)
      ~ bucket_key_enabled     = false -> (known after apply)
      + checksum_crc32         = (known after apply)
      + checksum_crc32c        = (known after apply)
      + checksum_sha1          = (known after apply)
      + checksum_sha256        = (known after apply)
      ~ etag                   = "31f350dbc9c402b7710e4e0b3e89ffd3" -> "b842ea042d4fbb1a079ff7f3beba3cd7"
      ~ id                     = "index.html" -> (known after apply)
      + kms_key_id             = (known after apply)
      - metadata               = {} -> null
      ~ server_side_encryption = "AES256" -> (known after apply)
      ~ storage_class          = "STANDARD" -> (known after apply)
      - tags                   = {} -> null
      ~ tags_all               = {} -> (known after apply)
      + version_id             = (known after apply)
        # (5 unchanged attributes hidden)
    }

  # module.terrahouse_aws.terraform_data.content_version will be updated in-place
  ~ resource "terraform_data" "content_version" {
        id     = "15199a74-5866-8caf-9230-be08e4e88785"
      ~ input  = 1 -> 2
      ~ output = 1 -> (known after apply)
    }

Plan: 1 to add, 1 to change, 1 to destroy.
```